### PR TITLE
FLOWSPACE-1: adding validation to avoid the cookies to be cooked with no fillings

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -12,8 +12,14 @@ class CookiesController < ApplicationController
 
   def create
     @oven = current_user.ovens.find_by!(id: params[:oven_id])
-    @cookie = @oven.create_cookie!(cookie_params)
-    redirect_to oven_path(@oven)
+
+    unless cookie_params[:fillings].present?
+      flash[:error] = "no fillings!"
+      redirect_to new_oven_cookies_path(@oven)
+    else
+      @cookie = @oven.create_cookie!(cookie_params)
+      redirect_to oven_path(@oven)
+    end
   end
 
   private

--- a/app/models/cookie.rb
+++ b/app/models/cookie.rb
@@ -3,6 +3,8 @@ class Cookie < ActiveRecord::Base
   
   validates :storage, presence: true
 
+  validates_presence_of :fillings, message: "no fillings!"
+
   def ready?
     true
   end

--- a/spec/controllers/cookies_controller_spec.rb
+++ b/spec/controllers/cookies_controller_spec.rb
@@ -5,7 +5,7 @@ describe CookiesController do
   let(:oven) { user.ovens.first }
 
   describe 'GET new' do
-    let(:the_request) { get :new, params: { oven_id: oven.id } }
+    let(:the_request) { get :new, params: { oven_id: oven.id, cookie: { fillings: "Coconut" } } }
 
     context "when not authenticated" do
       before { sign_in nil }
@@ -106,6 +106,20 @@ describe CookiesController do
             the_request
           }.to raise_error(ActiveRecord::RecordNotFound)
         end
+      end
+    end
+
+    context "when a cookie with an empty filling is baked" do
+      let(:cookie_params) {
+        {
+          fillings: ''
+        }
+      }
+
+      it "won't bake the cookie" do
+        expect {
+          the_request
+        }.to_not change{Cookie.count}
       end
     end
 

--- a/spec/features/cooking/cookies_spec.rb
+++ b/spec/features/cooking/cookies_spec.rb
@@ -43,6 +43,18 @@ feature 'Cooking cookies' do
     expect(page).to_not have_button 'Mix and bake'
   end
 
+  scenario 'Baking a cookie with no fillings' do
+    user = create_and_signin
+    oven = user.ovens.first
+
+    visit oven_path(oven)
+
+    click_link_or_button 'Prepare Cookie'
+    click_button 'Mix and bake'
+
+    expect(page).to have_content 'no fillings!'
+  end
+
   scenario 'Baking multiple cookies' do
     user = create_and_signin
     oven = user.ovens.first


### PR DESCRIPTION
As per requested, we don't to allow the cookies to be cooked without a fillings, so we are restricting the creation and showing a message.
Also we modified the test to validate this new behaviour.

All tests passed:
Finished in 2.13 seconds (files took 3.04 seconds to load)
54 examples, 0 failures, 1 pending